### PR TITLE
support nostd, standardize traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/betrusted-io/xous-semver/"
 homepage = "https://betrusted.io/"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-
 [features]
-std = []
 default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,323 +1,305 @@
-#[cfg(feature="std")]
-use std::process::Command;
-#[cfg(feature="std")]
-use std::convert::{From, Into, TryInto};
-use std::cmp::Ordering;
+#![no_std]
 
-#[derive(Eq, Debug)]
+use core::{
+    cmp::Ordering,
+    convert::{
+        From,
+        TryInto,
+    },
+    fmt::Formatter,
+    str::FromStr,
+};
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SemVer {
-    pub maj: u16,
-    pub min: u16,
-    pub rev: u16,
-    pub extra: u16,
+    pub maj:    u16,
+    pub min:    u16,
+    pub rev:    u16,
+    pub extra:  u16,
     pub commit: Option<u32>,
 }
-impl SemVer {
-    #[cfg(feature="std")]
-    pub fn from_git() -> Result<Self, &'static str> {
-        let output = if cfg!(target_os = "windows") {
-            Command::new("cmd")
-                .args(["/C", "git describe --tags"])
-                .output()
-                .map_err(|_| "failed to execute process")?
-        } else {
-            Command::new("sh")
-                .arg("-c")
-                .arg("git describe --tags")
-                .output()
-                .map_err(|_| "failed to execute process")?
-        };
-        let gitver = output.stdout;
-        let semver = String::from_utf8_lossy(&gitver);
-        SemVer::from_str(&semver)
-    }
-    #[cfg(feature="std")]
-    pub fn to_string(&self) -> String {
+
+impl core::fmt::Display for SemVer {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "v{}.{}.{}-{}", self.maj, self.min, self.rev, self.extra)?;
+
         if let Some(commit) = self.commit {
-            format!("v{}.{}.{}-{}-g{:x}",
-                self.maj, self.min, self.rev, self.extra, commit
-            )
-        } else {
-            format!("v{}.{}.{}-{}", self.maj, self.min, self.rev, self.extra)
+            write!(f, "-g{commit:x}")?;
         }
+
+        Ok(())
     }
-    pub fn from_str(revstr: &str) -> Result<Self, &'static str> {
-        let ver: Vec<&str> = revstr.trim_end().strip_prefix('v')
-            .ok_or("semver does not start with 'v'!")?
-            .split(['.', '-']).collect();
-        if ver.len() != 4 && ver.len() != 5 && ver.len() != 3 {
-            return Err("semver string has wrong number of fields");
+}
+
+impl SemVer {
+    #[cfg(feature = "std")]
+    pub fn from_git() -> Result<Self, &'static str> {
+        let output = std::process::Command::new("git")
+            .args(&["describe", "--tags"])
+            .output()
+            .map_err(|_| "failed to execute git")?;
+
+        let gitver = output.stdout;
+        let semver = core::str::from_utf8(&gitver).map_err(|_| "semver was not utf-8")?;
+
+        FromStr::from_str(semver)
+    }
+}
+
+impl FromStr for SemVer {
+    type Err = &'static str;
+
+    fn from_str(revstr: &str) -> Result<Self, &'static str> {
+        let revstr = revstr.trim_end();
+        let revstr = revstr.strip_prefix('v').unwrap_or(revstr);
+
+        #[inline]
+        fn parse_ver_int(s: &str) -> Result<u16, &'static str> {
+            u16::from_str(s).map_err(|_| "failed to parse version number as u16")
         }
-        let extra = if ver.len() == 5 {
-            u16::from_str_radix(ver[3], 10).map_err(|_| "error parsing extra")?
-        } else if ver.len() == 4 {
-            if ver[3].strip_prefix('g').is_some() {
-                0 // last string started with a 'g', it's a commit rev
-            } else { // interpret last string as extra, because no leading 'g'
-                u16::from_str_radix(ver[3], 10).map_err(|_| "error parsing extra")?
-            }
-        } else { // must be a length-3 string due to the check above
-            0
+
+        let (maj, rest): (_, &str) = revstr.split_once('.').ok_or_else(|| "no major version")?;
+        let maj = parse_ver_int(maj)?;
+
+        let (min, rest): (_, &str) = rest.split_once('.').ok_or_else(|| "no minor version")?;
+        let min = parse_ver_int(min)?;
+
+        let patch = rest.split_once('-');
+        let (patch, rest) = if let Some((patch, rest)) = patch {
+            (patch, rest)
+        } else {
+            (rest, "")
         };
-        Ok(SemVer {
-            maj: u16::from_str_radix(ver[0], 10).map_err(|_| "error parsing maj")?,
-            min: u16::from_str_radix(ver[1], 10).map_err(|_| "error parsing min")?,
-            rev: u16::from_str_radix(ver[2], 10).map_err(|_| "error parsing rev")?,
-            extra,
-            commit: if let Some(c) = ver[ver.len() - 1].strip_prefix('g') {
-                let trunc = if c.len() > 8 { &c[..8] } else { c };
-                Some(u32::from_str_radix(trunc, 16).map_err(|_| "error parsing commit")?)
-            } else {
-                None
+        let patch = parse_ver_int(patch)?;
+
+        if rest.is_empty() {
+            return Ok(SemVer {
+                maj,
+                min,
+                rev: patch,
+                extra: 0,
+                commit: None,
+            });
+        }
+
+        let (extra, commit) = if let Some((extra, commit)) = rest.split_once('-') {
+            if !commit.starts_with('g') {
+                return Err("invalid commit format (no 'g' prefix)");
             }
+
+            (parse_ver_int(extra)?, Some(&commit[1..commit.len().min(9)]))
+        } else {
+            if let Some(commit) = rest.strip_prefix('g') {
+                (0, Some(commit))
+            } else {
+                (parse_ver_int(rest)?, None)
+            }
+        };
+
+        let commit = commit
+            .map(|commit| u32::from_str_radix(commit, 16).map_err(|_| "parsing commit"))
+            .transpose()?;
+
+        Ok(SemVer {
+            maj,
+            min,
+            rev: patch,
+            extra,
+            commit,
         })
     }
 }
-impl From::<[u8; 16]> for SemVer {
+
+impl From<[u8; 16]> for SemVer {
     fn from(bytes: [u8; 16]) -> SemVer {
         // we use a whole word to store the `Option` flag, just to keep alignment at word alignment.
         let has_commit = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
         SemVer {
-            maj: u16::from_le_bytes(bytes[0..2].try_into().unwrap()),
-            min: u16::from_le_bytes(bytes[2..4].try_into().unwrap()),
-            rev: u16::from_le_bytes(bytes[4..6].try_into().unwrap()),
-            extra: u16::from_le_bytes(bytes[6..8].try_into().unwrap()),
-            commit: if has_commit != 0 {Some(u32::from_le_bytes(bytes[8..12].try_into().unwrap()))} else {None},
+            maj:    u16::from_le_bytes(bytes[0..2].try_into().unwrap()),
+            min:    u16::from_le_bytes(bytes[2..4].try_into().unwrap()),
+            rev:    u16::from_le_bytes(bytes[4..6].try_into().unwrap()),
+            extra:  u16::from_le_bytes(bytes[6..8].try_into().unwrap()),
+            commit: if has_commit != 0 {
+                Some(u32::from_le_bytes(bytes[8..12].try_into().unwrap()))
+            } else {
+                None
+            },
         }
     }
 }
-impl From::<&[u8; 16]> for SemVer {
-    fn from(bytes: &[u8; 16]) -> SemVer {
-        // we use a whole word to store the `Option` flag, just to keep alignment at word alignment.
-        let has_commit = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
-        SemVer {
-            maj: u16::from_le_bytes(bytes[0..2].try_into().unwrap()),
-            min: u16::from_le_bytes(bytes[2..4].try_into().unwrap()),
-            rev: u16::from_le_bytes(bytes[4..6].try_into().unwrap()),
-            extra: u16::from_le_bytes(bytes[6..8].try_into().unwrap()),
-            commit: if has_commit != 0 {Some(u32::from_le_bytes(bytes[8..12].try_into().unwrap()))} else {None},
-        }
+
+impl From<&[u8; 16]> for SemVer {
+    #[inline]
+    fn from(value: &[u8; 16]) -> Self {
+        SemVer::from(*value)
     }
 }
-impl Into::<[u8; 16]> for SemVer {
-    fn into(self) -> [u8; 16] {
+
+impl From<SemVer> for [u8; 16] {
+    fn from(value: SemVer) -> Self {
         let mut ser = [0u8; 16];
-        ser[0..2].copy_from_slice(&self.maj.to_le_bytes());
-        ser[2..4].copy_from_slice(&self.min.to_le_bytes());
-        ser[4..6].copy_from_slice(&self.rev.to_le_bytes());
-        ser[6..8].copy_from_slice(&self.extra.to_le_bytes());
-        ser[8..12].copy_from_slice(&self.commit.unwrap_or(0).to_le_bytes());
-        ser[12..16].copy_from_slice(&(if self.commit.is_some() {1u32} else {0u32}).to_le_bytes());
+        ser[0..2].copy_from_slice(&value.maj.to_le_bytes());
+        ser[2..4].copy_from_slice(&value.min.to_le_bytes());
+        ser[4..6].copy_from_slice(&value.rev.to_le_bytes());
+        ser[6..8].copy_from_slice(&value.extra.to_le_bytes());
+        ser[8..12].copy_from_slice(&value.commit.unwrap_or(0).to_le_bytes());
+        ser[12..16].copy_from_slice(
+            &(if value.commit.is_some() {
+                1u32
+            } else {
+                0u32
+            })
+            .to_le_bytes(),
+        );
         ser
     }
 }
-impl Into::<[u8; 16]> for &SemVer {
-    fn into(self) -> [u8; 16] {
-        let mut ser = [0u8; 16];
-        ser[0..2].copy_from_slice(&self.maj.to_le_bytes());
-        ser[2..4].copy_from_slice(&self.min.to_le_bytes());
-        ser[4..6].copy_from_slice(&self.rev.to_le_bytes());
-        ser[6..8].copy_from_slice(&self.extra.to_le_bytes());
-        ser[8..12].copy_from_slice(&self.commit.unwrap_or(0).to_le_bytes());
-        ser[12..16].copy_from_slice(&(if self.commit.is_some() {1u32} else {0u32}).to_le_bytes());
-        ser
+
+impl From<&SemVer> for [u8; 16] {
+    #[inline]
+    fn from(value: &SemVer) -> Self {
+        value.into()
     }
 }
-impl Ord for SemVer {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // we can just concatenate all the fields together and do a numerical comparison.
-        // commits are extra metadata in the record, and have no meaning in a comparison
-        let mine: u64 =
-            (self.maj as u64) << 48
-            | (self.min as u64) << 32
-            | (self.rev as u64) << 16
-            | (self.extra as u64);
-        let theirs: u64 =
-            (other.maj as u64) << 48
-            | (other.min as u64) << 32
-            | (other.rev as u64) << 16
-            | (other.extra as u64);
-        mine.cmp(&theirs)
-    }
-}
+
 impl PartialOrd for SemVer {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-impl PartialEq for SemVer {
-    // NOTE: equality also considers the commit rev
-    fn eq(&self, other: &Self) -> bool {
-        self.maj == other.maj
-        && self.min == other.min
-        && self.rev == other.rev
-        && self.extra == other.extra
-        && self.commit == other.commit
+
+impl Ord for SemVer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.maj
+            .cmp(&other.maj)
+            .then(self.min.cmp(&other.min))
+            .then(self.rev.cmp(&other.rev))
+            .then(self.extra.cmp(&other.extra))
     }
 }
+
 #[cfg(test)]
 mod tests {
+    use std::string::ToString;
+
     use super::*;
+
+    #[cfg(feature = "std")]
     #[test]
     fn test_gitver() {
-        let gitver = SemVer::from_git();
-        println!("{:?}", gitver);
-        assert!(gitver.is_ok());
+        let gitver = SemVer::from_git().unwrap();
+        std::println!("{:?}", gitver);
     }
+
     #[test]
     fn test_strver() {
         assert_eq!(
             SemVer::from_str("v0.9.8-760-gabcd1234"),
             Ok(SemVer {
-                maj: 0,
-                min: 9,
-                rev: 8,
-                extra: 760,
-                commit: Some(0xabcd1234)
+                maj:    0,
+                min:    9,
+                rev:    8,
+                extra:  760,
+                commit: Some(0xabcd1234),
             })
         );
         assert_eq!(
             SemVer::from_str("v0.9.8-760"),
             Ok(SemVer {
-                maj: 0,
-                min: 9,
-                rev: 8,
-                extra: 760,
-                commit: None
+                maj:    0,
+                min:    9,
+                rev:    8,
+                extra:  760,
+                commit: None,
             })
         );
         assert_eq!(
             SemVer::from_str("v0.9.8-gabcd1234"),
             Ok(SemVer {
-                maj: 0,
-                min: 9,
-                rev: 8,
-                extra: 0,
-                commit: Some(0xabcd1234)
+                maj:    0,
+                min:    9,
+                rev:    8,
+                extra:  0,
+                commit: Some(0xabcd1234),
             })
         );
         let bytes: [u8; 16] = SemVer::from_str("v0.9.8-760-gabcd1234").unwrap().into();
-        assert_eq!(
-            bytes,
-            [0, 0,
-            9, 0,
-            8, 0,
-            248, 2,
-            0x34, 0x12, 0xcd, 0xab,
-            0x01, 0, 0, 0
-            ]
-        );
+        assert_eq!(bytes, [0, 0, 9, 0, 8, 0, 248, 2, 0x34, 0x12, 0xcd, 0xab, 0x01, 0, 0, 0]);
         let bytes: [u8; 16] = SemVer::from_str("v0.9.8-760").unwrap().into();
-        assert_eq!(
-            bytes,
-            [0, 0,
-            9, 0,
-            8, 0,
-            248, 2,
-            0, 0, 0, 0,
-            0x00, 0, 0, 0
-            ]
-        );
+        assert_eq!(bytes, [0, 0, 9, 0, 8, 0, 248, 2, 0, 0, 0, 0, 0x00, 0, 0, 0]);
         let bytes: [u8; 16] = SemVer::from_str("v0.9.8-gabcd1234").unwrap().into();
-        assert_eq!(
-            bytes,
-            [0, 0,
-            9, 0,
-            8, 0,
-            0, 0,
-            0x34, 0x12, 0xcd, 0xab,
-            0x01, 0, 0, 0
-            ]
-        );
+        assert_eq!(bytes, [0, 0, 9, 0, 8, 0, 0, 0, 0x34, 0x12, 0xcd, 0xab, 0x01, 0, 0, 0]);
         let bytes: [u8; 16] = SemVer::from_str("v0.9.8").unwrap().into();
-        assert_eq!(
-            bytes,
-            [0, 0,
-            9, 0,
-            8, 0,
-            0, 0,
-            0, 0, 0, 0,
-            0x0, 0, 0, 0
-            ]
-        );
-        let bytes = [0, 0,
-        9, 0,
-        8, 0,
-        248, 2,
-        0x34, 0x12, 0xcd, 0xab,
-        0x01, 0, 0, 0
+        assert_eq!(bytes, [0, 0, 9, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0x0, 0, 0, 0]);
+        let bytes = [0, 0, 9, 0, 8, 0, 248, 2, 0x34, 0x12, 0xcd, 0xab, 0x01, 0, 0, 0];
+        assert_eq!(SemVer::from_str("v0.9.8-760-gabcd1234").unwrap(), SemVer::from(bytes));
+        let bytes = [
+            0, 0, 9, 0, 8, 0, 248, 2, 0x34, 0x12, 0xcd,
+            0xab, // these values should be ignored
+            0x00, 0, 0, 0,
         ];
-        assert_eq!(SemVer::from_str("v0.9.8-760-gabcd1234").unwrap(),
-            SemVer::from(bytes)
-        );
-        let bytes = [0, 0,
-        9, 0,
-        8, 0,
-        248, 2,
-        0x34, 0x12, 0xcd, 0xab, // these values should be ignored
-        0x00, 0, 0, 0
-        ];
-        assert_eq!(SemVer::from_str("v0.9.8-760").unwrap(),
-            SemVer::from(bytes)
-        );
+        assert_eq!(SemVer::from_str("v0.9.8-760").unwrap(), SemVer::from(bytes));
         assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() <
-            SemVer::from_str("v0.9.8-761-g0123456").unwrap()
-        );
-        assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() <
-            SemVer::from_str("v0.9.9-2").unwrap()
-        );
-        assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() <
-            SemVer::from_str("v1.0.0").unwrap()
-        );
-        assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() !=
-            SemVer::from_str("v0.9.8-760").unwrap()
-        );
-        assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() !=
-            SemVer::from_str("v0.9.8-760-g1234").unwrap()
-        );
-        assert!(
-            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() ==
             SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
+                < SemVer::from_str("v0.9.8-761-g0123456").unwrap()
+        );
+        assert!(
+            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
+                < SemVer::from_str("v0.9.9-2").unwrap()
+        );
+        assert!(
+            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap() < SemVer::from_str("v1.0.0").unwrap()
+        );
+        assert!(
+            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
+                != SemVer::from_str("v0.9.8-760").unwrap()
+        );
+        assert!(
+            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
+                != SemVer::from_str("v0.9.8-760-g1234").unwrap()
+        );
+        assert!(
+            SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
+                == SemVer::from_str("v0.9.8-760-gabcd1234").unwrap()
         );
         let sv = Some(SemVer::from_str("v0.9.8-760-gabcd1234").unwrap());
-        let bytes: [u8; 16] = if let Some(svb) = &sv {
+        let bytes: [u8; 16] = if let Some(svb) = sv {
             svb.into()
         } else {
             [0u8; 16]
         };
-        assert_eq!(
-            bytes,
-            [0, 0,
-            9, 0,
-            8, 0,
-            248, 2,
-            0x34, 0x12, 0xcd, 0xab,
-            0x01, 0, 0, 0
-            ]
-        );
-        let bytes = [0, 0,
-        9, 0,
-        8, 0,
-        248, 2,
-        0x34, 0x12, 0xcd, 0xab, // these values should be ignored
-        0x00, 0, 0, 0
+        assert_eq!(bytes, [0, 0, 9, 0, 8, 0, 248, 2, 0x34, 0x12, 0xcd, 0xab, 0x01, 0, 0, 0]);
+        let bytes = [
+            0, 0, 9, 0, 8, 0, 248, 2, 0x34, 0x12, 0xcd,
+            0xab, // these values should be ignored
+            0x00, 0, 0, 0,
         ];
-        assert_eq!(SemVer::from_str("v0.9.8-760").unwrap(),
-            SemVer::from(&bytes)
-        );
-        assert_eq!(SemVer {
-            maj: 0, min: 9, rev: 8, extra: 42, commit: None
-        }.to_string(),
+        assert_eq!(SemVer::from_str("v0.9.8-760").unwrap(), SemVer::from(bytes));
+        assert_eq!(
+            SemVer {
+                maj:    0,
+                min:    9,
+                rev:    8,
+                extra:  42,
+                commit: None,
+            }
+            .to_string(),
             "v0.9.8-42".to_string()
         );
-        assert_eq!(SemVer {
-            maj: 0, min: 9, rev: 8, extra: 42, commit: Some(0x123abc)
-        }.to_string(),
+        assert_eq!(
+            SemVer {
+                maj:    0,
+                min:    9,
+                rev:    8,
+                extra:  42,
+                commit: Some(0x123abc),
+            }
+            .to_string(),
             "v0.9.8-42-g123abc".to_string()
         );
     }


### PR DESCRIPTION
Provides support for #![no_std] in the crate, which previously didn't declare itself as such, even with the `std` feature flag turned off. This is needed to remove std dependencies from certain parts of xous-core for use in baremetal.

Eliminates dependency on `Vec` for parsing: this is now done incrementally and without allocation. `String` is similarly not required for the `to_string` implementation, which is moved to `Display` (which is invoked implicitly by the blanket `ToString` impl).

Cleans up `from_git`, which no longer wraps the `git` shell-out with `cmd` or `sh`, rather just invoking the executable directly.

Removes the manual bit-hacking from the `Ord` impl, replacing it with the ergonomic/intended `core::cmp::Ordering::then` ([which appears more transparent to optimization](https://godbolt.org/z/a7MxjjjhT)).

Also standardizes on common traits and updates derives -- SemVer is now Copy, Clone, and Hash. As mentioned, `to_string` is now implemented by means of `Display` (sans allocation), and is invokable via `ToString`. `from_str` moved to `FromStr`. `impl Into<[u8; 16]> for SemVer` replaced with `impl From<SemVer> for [u8; 16]` ([user types shouldn't impl `Into`](https://doc.rust-lang.org/std/convert/trait.Into.html)). From<T>/From<&T> implementations deduplicated. `PartialEq` changed to derive rather than manual implementation (as it just implemented the derive semantics).